### PR TITLE
Update 3_build_own_libs.sh (fix create subdirs [tuxtxt])

### DIFF
--- a/3_build_own_libs.sh
+++ b/3_build_own_libs.sh
@@ -163,7 +163,7 @@ else
 	if [[ $? -eq 0 ]]; then
 		echo "$PKG already installed"
 	else
-		mkdir $INSTALL_E2DIR/lib/enigma2/python/Plugins/Extensions/$DIR
+		mkdir -p $INSTALL_E2DIR/lib/enigma2/python/Plugins/Extensions/$DIR
 		cd $PKG
 
 		#autoupdate


### PR DESCRIPTION
-p parameter is needed for creating the subdirectories otherwise the libtuxtxt32bpp.* files  will not be created and compiling and linking of enigma2 will fail later.